### PR TITLE
隐藏上下文菜单和光标,解决点击时输入顺序错乱的 BUG

### DIFF
--- a/vcedittext-lib/src/main/java/com/jkb/vcedittext/VerificationCodeEditText.java
+++ b/vcedittext-lib/src/main/java/com/jkb/vcedittext/VerificationCodeEditText.java
@@ -12,7 +12,9 @@ import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
+import android.view.MotionEvent;
 import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
 
 
 /**
@@ -118,6 +120,17 @@ public class VerificationCodeEditText extends android.support.v7.widget.AppCompa
             heightResult = mEachRectLength;
         }
         setMeasuredDimension(widthResult, heightResult);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (event.getAction() == MotionEvent.ACTION_DOWN) {
+            requestFocus();
+            setSelection(getText().length());
+            showKeyBoard(getContext());
+            return false;
+        }
+        return super.onTouchEvent(event);
     }
 
     @Override
@@ -259,5 +272,10 @@ public class VerificationCodeEditText extends android.support.v7.widget.AppCompa
         WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
         wm.getDefaultDisplay().getMetrics(metrics);
         return metrics.widthPixels;
+    }
+
+    public void showKeyBoard(Context context) {
+        InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm.showSoftInput(this, InputMethodManager.SHOW_FORCED);
     }
 }


### PR DESCRIPTION
1.长按前部会出现上下文菜单和光标
![image](https://user-images.githubusercontent.com/8948303/33535428-6f1a6516-d8e8-11e7-942c-73cbd1afb035.png)

2.当初始有数字时,点击前部,再输入,顺序会错乱

3.点击时不会自动弹出键盘 

解决: 重写`onTouch()`,当`ACTION_DOWN `时,不消费该事件,并弹出键盘

望 REVIEW

thx.